### PR TITLE
fix: remove unused trait bound in Sequence::from_array

### DIFF
--- a/src/err_marker.mbt
+++ b/src/err_marker.mbt
@@ -23,7 +23,7 @@ fn[T : Show] err_locate_arr(
   seq : Array[T],
   pos : Int,
   offset : Int,
-  join~ : Int = 1
+  join~ : Int = 1,
 ) -> (Int, Int) {
   guard pos >= 0 && pos < seq.length() && offset >= 0 else { (-1, -1) }
   let start = seq.foldi(init=0, (i, acc, x) => if i < pos {
@@ -62,7 +62,7 @@ fn[T : Show] gen_marker(
   seq : Sequence[T],
   pos : Int,
   offset : Int,
-  marker : Char
+  marker : Char,
 ) -> String {
   match seq {
     Arr(a, j) => {
@@ -122,7 +122,7 @@ pub fn[T : Show] ErrorData::mark(
   self : ErrorData,
   seq : Sequence[T],
   marker~ : Char = '^',
-  gen_msg~ : (String?, String) -> String = gen_err_msg
+  gen_msg~ : (String?, String) -> String = gen_err_msg,
 ) -> String {
   let (pos, offset) = (self.err_pos, self.err_offset)
   let seq_str = match seq {

--- a/src/err_marker.mbti
+++ b/src/err_marker.mbti
@@ -16,7 +16,7 @@ fn ErrorData::make(err_type? : String?, String, err_pos? : Int, err_offset? : In
 fn[T : Show] ErrorData::mark(Self, Sequence[T], marker? : Char, gen_msg? : (String?, String) -> String) -> String
 
 type Sequence[T]
-fn[T : Show] Sequence::from_array(Array[T], join? : String) -> Self[T]
+fn[T] Sequence::from_array(Array[T], join? : String) -> Self[T]
 fn Sequence::from_string(String) -> Self[Char]
 
 // Type aliases

--- a/src/err_marker.mbti
+++ b/src/err_marker.mbti
@@ -1,6 +1,9 @@
+// Generated using `moon info`, DON'T EDIT IT
 package "KCN-judu/err_marker"
 
 // Values
+
+// Errors
 
 // Types and methods
 pub struct ErrorData {
@@ -9,11 +12,11 @@ pub struct ErrorData {
   err_pos : Int
   err_offset : Int
 }
-fn ErrorData::make(err_type~ : String? = .., String, err_pos~ : Int = .., err_offset~ : Int = ..) -> Self
-fn[T : Show] ErrorData::mark(Self, Sequence[T], marker~ : Char = .., gen_msg~ : (String?, String) -> String = ..) -> String
+fn ErrorData::make(err_type? : String?, String, err_pos? : Int, err_offset? : Int) -> Self
+fn[T : Show] ErrorData::mark(Self, Sequence[T], marker? : Char, gen_msg? : (String?, String) -> String) -> String
 
 type Sequence[T]
-fn[T : Show] Sequence::from_array(Array[T], join~ : String = ..) -> Self[T]
+fn[T : Show] Sequence::from_array(Array[T], join? : String) -> Self[T]
 fn Sequence::from_string(String) -> Self[Char]
 
 // Type aliases

--- a/src/err_type.mbt
+++ b/src/err_type.mbt
@@ -13,7 +13,7 @@ enum Sequence[T] {
 }
 
 ///|
-pub fn[T : Show] Sequence::from_array(
+pub fn[T] Sequence::from_array(
   arr : Array[T],
   join~ : String = " ",
 ) -> Sequence[T] {

--- a/src/err_type.mbt
+++ b/src/err_type.mbt
@@ -15,7 +15,7 @@ enum Sequence[T] {
 ///|
 pub fn[T : Show] Sequence::from_array(
   arr : Array[T],
-  join~ : String = " "
+  join~ : String = " ",
 ) -> Sequence[T] {
   Arr(arr, join)
 }
@@ -38,7 +38,7 @@ pub fn ErrorData::make(
   err_type~ : String? = None,
   err_msg : String,
   err_pos~ : Int = -1,
-  err_offset~ : Int = 0
+  err_offset~ : Int = 0,
 ) -> ErrorData {
   ErrorData::{ err_type, err_msg, err_pos, err_offset }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Remove the unused `Show` trait bound from the `Sequence::from_array` function signature. The trait bound was not being used in the function implementation, causing a compiler warning.

This change fixes warning[0053]: "This trait bound is unused."